### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that enables CRUD operations on a WebDAV endpoint with basic authentication. This server enables Claude Desktop and other MCP clients to interact with WebDAV file systems through natural language commands.
 
+<a href="https://glama.ai/mcp/servers/@LaubPlusCo/mcp-webdav-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LaubPlusCo/mcp-webdav-server/badge" alt="WebDAV Server MCP server" />
+</a>
+
 ## Features
 
 - Connect to any WebDAV server with optional authentication


### PR DESCRIPTION
This PR adds a badge for the [WebDAV MCP Server](https://glama.ai/mcp/servers/@LaubPlusCo/mcp-webdav-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@LaubPlusCo/mcp-webdav-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LaubPlusCo/mcp-webdav-server/badge" alt="WebDAV Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.